### PR TITLE
Starting containers and waiting for ports in parallel threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>me.bazhenov</groupId>
 	<artifactId>docker-testng-integration</artifactId>
-	<version>1.4</version>
+	<version>1.5</version>
 	<packaging>jar</packaging>
 
 	<name>docker-testng-integration</name>

--- a/src/main/java/me/bazhenov/docker/Docker.java
+++ b/src/main/java/me/bazhenov/docker/Docker.java
@@ -17,6 +17,7 @@ import static java.nio.file.Files.readAllLines;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.ConcurrentHashMap.newKeySet;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.joining;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -37,7 +38,7 @@ public final class Docker implements Closeable {
 	private static final ObjectMapper jsonReader = new ObjectMapper();
 
 	private final String pathToDocker;
-	private final Set<String> containersToRemove = new HashSet<>();
+	private final Set<String> containersToRemove = newKeySet();
 
 	public Docker(String pathToDocker) {
 		this.pathToDocker = requireNonNull(pathToDocker);


### PR DESCRIPTION
Starting many containers and waiting for ports in serial mode may be time consuming. This commit should seriously reduce the time.