### PR TITLE
Fixed start container without IPv6 and simple shell

### DIFF
--- a/src/main/java/me/bazhenov/docker/Docker.java
+++ b/src/main/java/me/bazhenov/docker/Docker.java
@@ -38,6 +38,8 @@ public final class Docker implements Closeable {
 	private static final Logger log = getLogger(Docker.class);
 	private static final ObjectMapper jsonReader = new ObjectMapper();
 
+	List<String> tcpFiles = asList("/proc/self/net/tcp", "/proc/self/net/tcp6");
+
 	private final String pathToDocker;
 	private final Set<String> containersToRemove = newKeySet();
 	private final Set<String> networks = newKeySet();
@@ -296,12 +298,11 @@ public final class Docker implements Closeable {
 	private void waitForPorts(String cid, Set<Integer> ports) throws IOException, InterruptedException {
 		Thread self = currentThread();
 		long start = currentTimeMillis();
-		List<String> tcpFiles = asList("/proc/self/net/tcp", "/proc/self/net/tcp6");
 		boolean reported = false;
 		while (!self.isInterrupted()) {
 			Set<Integer> openPorts = new HashSet<>();
 			for (String file : tcpFiles) {
-				openPorts.addAll(readListenPorts(docker("exec", cid, "sh", "-c", "[[ ! -f " + file + " ]] || cat " + file)));
+				openPorts.addAll(readListenPorts(docker("exec", cid, "sh", "-c", "[ ! -f " + file + " ] || cat " + file)));
 			}
 			if (openPorts.containsAll(ports))
 				return;

--- a/src/test/java/me/bazhenov/docker/DockerTest.java
+++ b/src/test/java/me/bazhenov/docker/DockerTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static java.util.Arrays.asList;
 import static me.bazhenov.docker.Docker.readListenPorts;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -52,6 +53,17 @@ public class DockerTest {
 	@Test
 	public void executeDemonizedContainer() throws IOException, InterruptedException {
 		ContainerDefinition execution = new ContainerDefinition("alpine", "nc", "-lp", "1234", "-s", "0.0.0.0");
+		execution.addPublishedPort(1234);
+
+		String containerName = docker.start(execution);
+		Map<Integer, Integer> ports = docker.getPublishedTcpPorts(containerName);
+		assertThat(ports, hasKey(1234));
+	}
+
+	@Test
+	public void executeContainerWaitingForPublishedPortsWithRealShShellAndNotExistsTcpFile() throws Exception {
+		docker.tcpFiles = asList("/proc/self/net/tcp", "/proc/self/net/tcp6", "/proc/self/net/tcp-not-exists");
+		ContainerDefinition execution = new ContainerDefinition("ubuntu:14.04", "nc", "-l", "-p", "1234");
 		execution.addPublishedPort(1234);
 
 		String containerName = docker.start(execution);


### PR DESCRIPTION
Sorry! Previous fix was not correct. It uses bashism '[[' which simple sh-shell does not understand. Old tests did not catch this situation because all of it uses 'Alpine' docker image where /bin/sh is not real sh-shell but busybox link which is smarter.
I added simple test with Ubuntu image to reproduce the problem.